### PR TITLE
Fix SQLite Directory Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,5 @@ cython_debug/
 #.idea/
 out/*.csv
 *.db
-cli_chronicler/sql/test_*
+cli_chronicler/test_data.sql
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.1
+
+Released on February 19, 2024.
+
+### Fixed
+
+* A bug that prevented users who pip installed from initializing the sqlite database file.
+
 ## 0.6.0
 
 Released on February 18, 2024.

--- a/cli_chronicler/main.py
+++ b/cli_chronicler/main.py
@@ -5,9 +5,7 @@ import os
 from cli_chronicler.src.reporter import generate_daily_report, retrieve_open_punches
 
 # Global Constants
-DB_FILE_PATH = "cli_chronicler/db/punch_db.db"
-SQL_FILE_PATH = "cli_chronicler/sql/time_punch_events.sql"
-
+DB_FILE_PATH = ".chronicler/punch_db.db"
 
 class TimePunchEvent:
     """Class for keeping track of a time punch event."""
@@ -30,10 +28,16 @@ class TimePunchEvent:
             )
 
 
-def build_tables(sql_file_path, conn):
-    with open(sql_file_path) as f:
-        for statement in f.read().split("\n\n"):
-            conn.execute(statement)
+def build_tables(conn):
+    with conn:
+        conn.execute(
+            """
+create table if not exists time_punch_events (
+    time_punched_at_utc text,
+    time_punched_at_local text,
+    description text
+);"""
+        )
 
 
 def main():
@@ -56,8 +60,9 @@ def main():
             conn = sqlite3.connect(DB_FILE_PATH)
             punch_to_log.write_event_to_db(conn)
         else:  # If the db file does not exist, then create new file, create tables, and insert.
+            os.mkdir(".chronicler")
             conn = sqlite3.connect(DB_FILE_PATH)
-            build_tables(SQL_FILE_PATH, conn)
+            build_tables(conn)
             punch_to_log.write_event_to_db(conn)
 
 

--- a/cli_chronicler/sql/time_punch_events.sql
+++ b/cli_chronicler/sql/time_punch_events.sql
@@ -1,7 +1,0 @@
-drop table if exists time_punch_events;
-
-create table if not exists time_punch_events (
-    time_punched_at_utc text,
-    time_punched_at_local text,
-    description text
-);

--- a/cli_chronicler/src/reporter.py
+++ b/cli_chronicler/src/reporter.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-DB_FILE_PATH = "cli_chronicler/db/punch_db.db"
+DB_FILE_PATH = ".chronicler/punch_db.db"
 HOURS_BY_CATEGORY = """
 -- hours by category
 select

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="cli_chronicler",
-    version="0.6.0",
+    version="0.6.1",
     packages=find_packages(),
     entry_points={"console_scripts": ["punch = cli_chronicler:main"]},
     description="A command line app for keeping track of project/work times.",


### PR DESCRIPTION
## What is the problem?

* Users who pip install from PyPi cannot use the app because the SQLite file does not exist and the relative directories in the script are inaccessible by the script

## What is the resolution?

* Remove non-necessary scripts from the package
* Embed SQL for creating tables directly instead of reading it from files
* Add an os.mkdir() call to create a directory the script can access for writing db files